### PR TITLE
Update instalar_ros_melodic.md

### DIFF
--- a/guides/instalar_ros_melodic.md
+++ b/guides/instalar_ros_melodic.md
@@ -59,7 +59,7 @@ Vamos obter o software que falta para controle do Turtlebot clonando os reposit�
     git clone https://github.com/ROBOTIS-GIT/turtlebot3_applications.git  
 
 
-    cd ~/catkin_ws/src
+    cd ~/catkin_ws/
     catkin_make
 
 Adicionar a configuração do robô ao `.bashrc`


### PR DESCRIPTION
Atualizada a linha que se refere ao catkin_make após clonar os repositórios do turtlebot para fazer o make no diretório correto.